### PR TITLE
Adding missing en translation of extra_states.presence

### DIFF
--- a/src/localize/languages/en.json
+++ b/src/localize/languages/en.json
@@ -41,6 +41,7 @@
     "frost": "Frost",
     "power": "Overpowering",
     "activity": "Activity detected",
+    "presence": "Presence detected",
     "motion": "Motion detected",
     "undefined": "None",
     "auto_regulation_light": "Light",


### PR DESCRIPTION
`fr` localisation is also missing `extra_states.night_mode`, `extra_states.undefined`, and `editor.card.climate.disable_menu` which are present in the `en` file.

I can add these too if you can provide the translation please @jmcollin78 